### PR TITLE
Add skaffold for debugging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
-deploy.yaml
-README.md
+*.yaml
+*.md
+LICENSE
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 deploy.yaml
+skaffold.yaml

--- a/Dedicated.Dockerfile
+++ b/Dedicated.Dockerfile
@@ -20,8 +20,9 @@ WORKDIR /go/src/github.com/googleforgames/space-agon
 COPY go.sum go.mod ./
 RUN go mod download
 
-COPY . .
 RUN mkdir /app
+COPY dedicated ./dedicated
+COPY game ./game
 RUN CGO_ENABLED=0 go build -installsuffix cgo -o /app/dedicated github.com/googleforgames/space-agon/dedicated
 
 FROM gcr.io/distroless/static:nonroot

--- a/Director.Dockerfile
+++ b/Director.Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /go/src/github.com/googleforgames/space-agon
 COPY go.sum go.mod ./
 RUN go mod download
 
-COPY . .
 RUN mkdir /app
+COPY director ./director
 RUN CGO_ENABLED=0 go build -installsuffix cgo -o /app/director github.com/googleforgames/space-agon/director
 
 FROM gcr.io/distroless/static:nonroot

--- a/Frontend.Dockerfile
+++ b/Frontend.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.7-alpine3.15 as builder
+FROM golang:1.17.7 as builder
 ENV GO111MODULE=on
 
 WORKDIR /go/src/github.com/googleforgames/space-agon
@@ -20,10 +20,12 @@ WORKDIR /go/src/github.com/googleforgames/space-agon
 COPY go.sum go.mod ./
 RUN go mod download
 
-COPY . .
 RUN mkdir /app
+COPY frontend ./frontend
+COPY game ./game
+COPY client ./client
+COPY static /app/static
 RUN CGO_ENABLED=0 go build -installsuffix cgo -o /app/frontend github.com/googleforgames/space-agon/frontend
-RUN cp -r static /app/static
 RUN GOOS=js GOARCH=wasm go build -o /app/static/client.wasm github.com/googleforgames/space-agon/client
 RUN cp /usr/local/go/misc/wasm/wasm_exec.js /app/static/
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ help:
 	@echo "Uninstall Space Agon"
 	@echo "    make uninstall"
 	@echo ""
+	@echo "Setup a Skaffold file for debugging !!RUN AFTER CREATING YOUR CLUSTER!!"
+	@echo "    make skaffold-setup"
+	@echo ""
 
 # build space-agon docker images
 .PHONY: build
@@ -91,9 +94,9 @@ agones-uninstall:
 .PHONY: openmatch-install
 openmatch-install:
 	kubectl create namespace open-match
-	kubectl apply -f https://open-match.dev/install/v1.3.0/yaml/01-open-match-core.yaml \
-		-f https://open-match.dev/install/v1.3.0/yaml/06-open-match-override-configmap.yaml \
-		-f https://open-match.dev/install/v1.3.0/yaml/07-open-match-default-evaluator.yaml \
+	kubectl apply -f https://open-match.dev/install/v1.4.0/yaml/01-open-match-core.yaml \
+		-f https://open-match.dev/install/v1.4.0/yaml/06-open-match-override-configmap.yaml \
+		-f https://open-match.dev/install/v1.4.0/yaml/07-open-match-default-evaluator.yaml \
 		--namespace open-match
 
 # uninstall open-match
@@ -101,6 +104,10 @@ openmatch-install:
 openmatch-uninstall:
 	kubectl delete psp,clusterrole,clusterrolebinding --selector=release=open-match
 	kubectl delete namespace open-match
+
+.PHONY: skaffold-setup
+skaffold-setup:
+	./scripts/setup-skaffold.sh ${PROJECT} ${REGISTRY}
 
 # install space-agon itself
 .PHONY: install

--- a/Mmf.Dockerfile
+++ b/Mmf.Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /go/src/github.com/googleforgames/space-agon
 COPY go.sum go.mod ./
 RUN go mod download
 
-COPY . .
 RUN mkdir /app
+COPY mmf ./mmf
 RUN CGO_ENABLED=0 go build -installsuffix cgo -o /app/mmf github.com/googleforgames/space-agon/mmf
 
 FROM gcr.io/distroless/static:nonroot

--- a/README.md
+++ b/README.md
@@ -2,33 +2,38 @@ The original work is [Laremere/space-agon](https://github.com/Laremere/space-ago
 
 # Space Agon
 
-Space Agon is a demo of [Agones](https://agones.dev/) and
-[Open Match](https://open-match.dev/). You can try integrations of Gaming OSS.
+Space Agon is a integrated demo of [Agones](https://agones.dev/) and
+[Open Match](https://open-match.dev/).
 
-## Before Installing
+## Before Trying.
 
-**Warning**: Be aware of billing charges for running the cluster.  
+**Be aware of billing charges for running the cluster.**
 
-Space Agon has been tested on this cluster size (nodes and machine types), but a small cluster may be sufficient for your use.    
-Don't leave the cluster running when you're not using it if you're concerned about cost. See [pricing](https://cloud.google.com/kubernetes-engine/pricing) for more.
+Space Agon is intended to run on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) and has been tested with the configured cluster size .   
+Leaving the cluster running may incur your cost. You need to take responsibility for it.  (See pricings of [GKE](https://cloud.google.com/kubernetes-engine/pricing), [Cloud Build](https://cloud.google.com/build/pricing) and [Artifact Registry](https://cloud.google.com/artifact-registry/pricing).) 
 
 ## Prerequisites
 
-You need to install tools:
+Create your [Google Cloud Project](https://cloud.google.com/) to test and deploy.
 
-- [docker](https://www.docker.com/)
+You need to install tools in your dev environment:
+
 - [gcloud](https://cloud.google.com/sdk/gcloud)
+- [docker](https://www.docker.com/)
 - [kubectl](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_kubectl)
+- [skaffold](https://skaffold.dev/) (Optional)
 
-[Google Cloud Shell](https://cloud.google.com/shell) has all tools you need.
+_[Google Cloud Shell](https://cloud.google.com/shell) has all tools you need._
 
 ## Create the Resources and Install Gaming OSS
 
-```sh
+```bash
+# Set Your Project ID before you run
+PROJECT_ID=<your project ID>
+
 LOCATION=us-central1
 ZONE=$LOCATION-a
-# Set Your Project ID before you run
-PROJECT_ID=<your project id>
+
 REPOSITORY=space-agon
 
 gcloud services enable artifactregistry.googleapis.com \
@@ -68,11 +73,11 @@ make openmatch-install
 
 Make sure you installed docker to build and push images
 
-```sh
-# build space-agon images
+```bash
+# Build space-agon images
 make build
 
-# apply space-agon images
+# Apply space-agon images
 make install
 ```
 
@@ -80,7 +85,7 @@ make install
 
 Get External IP from:
 
-```sh
+```bash
 kubectl get service frontend
 ```
 
@@ -90,7 +95,7 @@ match" to start searching for a match.
 Repeat in a second web browser window to create a second player, the players
 will be connected and can play each other.
 
-## Additional Things to do
+## Testing Space-Agon
 
 View Running Game Servers:
 
@@ -124,6 +129,32 @@ make openmatch-uninstall
 ```sh
 gcloud projects delete $PROJECT_ID
 ```
+
+## Development
+
+In case testing your original match making logics, [`skaffold`](https://skaffold.dev/) can help you to debug in the space-agon cluster. 
+
+### Setup
+
+1. Create a space-agon k8s cluster.
+1. [Install `skaffold`](https://skaffold.dev/docs/install/) if you haven't installed. 
+1. Run `make skaffold-setup` on the project root to create a `skaffold.yaml`
+
+Now you're ready to run `skaffold` commands.
+
+### Debug
+
+Once you create a `skaffold.yaml`, you can run `skaffold` commands.
+
+```bash
+# Build space-agon images with Cloud Build
+skaffold build 
+
+# Run Applicaitons in the space-agon cluster for debugging.
+skaffold dev
+```
+
+Changing files triggers Build and Deploy on the fly. For more commands and details, visit [`skaffold`](https://skaffold.dev/). 
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Space Agon is a integrated demo of [Agones](https://agones.dev/) and
 **Be aware of billing charges for running the cluster.**
 
 Space Agon is intended to run on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) and has been tested with the configured cluster size.   
-Leaving the cluster running may incur your cost. You need to take responsibility for it.  (See pricings of [GKE](https://cloud.google.com/kubernetes-engine/pricing), [Cloud Build](https://cloud.google.com/build/pricing) and [Artifact Registry](https://cloud.google.com/artifact-registry/pricing).) 
+Leaving the cluster running may incur your cost. You need to be responsible for the cost.  (See pricings of [GKE](https://cloud.google.com/kubernetes-engine/pricing), [Cloud Build](https://cloud.google.com/build/pricing) and [Artifact Registry](https://cloud.google.com/artifact-registry/pricing).) 
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Space Agon is a integrated demo of [Agones](https://agones.dev/) and
 
 **Be aware of billing charges for running the cluster.**
 
-Space Agon is intended to run on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) and has been tested with the configured cluster size .   
+Space Agon is intended to run on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) and has been tested with the configured cluster size.   
 Leaving the cluster running may incur your cost. You need to take responsibility for it.  (See pricings of [GKE](https://cloud.google.com/kubernetes-engine/pricing), [Cloud Build](https://cloud.google.com/build/pricing) and [Artifact Registry](https://cloud.google.com/artifact-registry/pricing).) 
 
 ## Prerequisites
 
-Create your [Google Cloud Project](https://cloud.google.com/) to test and deploy.
+Create your [Google Cloud Project](https://cloud.google.com/).
 
-You need to install tools in your dev environment:
+Install tools in your dev environment:
 
 - [gcloud](https://cloud.google.com/sdk/gcloud)
 - [docker](https://www.docker.com/)
@@ -69,7 +69,7 @@ make agones-install
 make openmatch-install
 ```
 
-## Commands to deploy
+## Deploy applications
 
 Make sure you installed docker to build and push images
 
@@ -95,7 +95,7 @@ match" to start searching for a match.
 Repeat in a second web browser window to create a second player, the players
 will be connected and can play each other.
 
-## Testing Space-Agon
+## Access GameServer
 
 View Running Game Servers:
 
@@ -130,21 +130,23 @@ make openmatch-uninstall
 gcloud projects delete $PROJECT_ID
 ```
 
-## Development
+## Develop Applications
 
-In case testing your original match making logics, [`skaffold`](https://skaffold.dev/) can help you to debug in the space-agon cluster. 
+In case testing your original match making logics, [`skaffold`](https://skaffold.dev/) can help you debug your applications. 
 
 ### Setup
 
 1. Create a space-agon k8s cluster.
-1. [Install `skaffold`](https://skaffold.dev/docs/install/) if you haven't installed. 
-1. Run `make skaffold-setup` on the project root to create a `skaffold.yaml`
+1. [Install `skaffold`](https://skaffold.dev/docs/install/) if you haven't. 
+1. Run `make skaffold-setup` on the project root to make a `skaffold.yaml`
 
 Now you're ready to run `skaffold` commands.
 
 ### Debug
 
 Once you create a `skaffold.yaml`, you can run `skaffold` commands.
+
+You can check your own logic and debug.
 
 ```bash
 # Build space-agon images with Cloud Build
@@ -154,7 +156,7 @@ skaffold build
 skaffold dev
 ```
 
-Changing files triggers Build and Deploy on the fly. For more commands and details, visit [`skaffold`](https://skaffold.dev/). 
+Modifying applications during `skaffold dev` triggers Build and Deploy automatically. For more commands and details, visit [`skaffold`](https://skaffold.dev/). 
 
 ## LICENSE
 

--- a/scripts/setup-skaffold.sh
+++ b/scripts/setup-skaffold.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2022 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT RUN this script directly.
+# Run `make skaffold-setup` command after creating the cluster.
+# This script setup skaffold.yaml
+
+PROJECT_ID=$1
+REGISTRY=$2
+
+gcloud config set project $PROJECT_ID
+gcloud services enable cloudbuild.googleapis.com
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
+    --format="value(projectNumber)")@cloudbuild.gserviceaccount.com \
+    --role="roles/storage.objectViewer"
+
+ESC_REGISTRY=$(echo ${REGISTRY} | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g') &&
+sed -E 's/image: (.*)\/([^\/]*)/image: '${ESC_REGISTRY}'\/\2/;s/PROJECTID/'${PROJECT_ID}'/g' skaffold_template.yaml > skaffold.yaml
+
+echo "You are ready to run skaffold commands"

--- a/scripts/setup-skaffold.sh
+++ b/scripts/setup-skaffold.sh
@@ -21,11 +21,11 @@
 PROJECT_ID=$1
 REGISTRY=$2
 
-gcloud config set project $PROJECT_ID
+gcloud config set project ${PROJECT_ID}
 gcloud services enable cloudbuild.googleapis.com
 
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-    --member=serviceAccount:$(gcloud projects describe $PROJECT_ID \
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member=serviceAccount:$(gcloud projects describe ${PROJECT_ID} \
     --format="value(projectNumber)")@cloudbuild.gserviceaccount.com \
     --role="roles/storage.objectViewer"
 

--- a/skaffold_template.yaml
+++ b/skaffold_template.yaml
@@ -1,0 +1,59 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skaffold/v2beta29
+kind: Config
+metadata:
+  name: space-agon
+build:
+  tagPolicy:
+    gitCommit:
+      variant: CommitSha
+      prefix: ska-dev-
+  artifacts:
+  - image: REGISTRY/space-agon-dedicated
+    context: ./
+    docker:
+      dockerfile: Dedicated.Dockerfile
+  - image: REGISTRY/space-agon-director
+    context: ./
+    docker:
+      dockerfile: Director.Dockerfile
+  - image: REGISTRY/space-agon-frontend
+    context: ./
+    docker:
+      dockerfile: Frontend.Dockerfile
+  - image: REGISTRY/space-agon-mmf
+    context: ./
+    docker:
+      dockerfile: Mmf.Dockerfile
+  googleCloudBuild:
+    projectId: PROJECTID
+    timeout: "600s"
+    concurrency: 0
+    region: "us-central1"
+test:
+  - context: .
+    image: REGISTRY/space-agon-dedicated
+  - context: .
+    image: REGISTRY/space-agon-director
+  - context: .
+    image: REGISTRY/space-agon-frontend
+  - context: .
+    image: REGISTRY/space-agon-mmf
+
+deploy:
+  kubectl:
+    manifests:
+    - deploy.yaml


### PR DESCRIPTION
When we want to modify the space-agon and try our original logics, we have to build and deploy by ourselves currently. This PR enables us to run the cluster with `skaffold` command. 

- Changed `Dockerfiles` to reduce their image size
- Created `make skaffold-setup` for `skaffold`
- Canged README.md
- Updated Open Match  to `v1.4.0`

Closes (#5)
