### PR TITLE
Fix: k8s version of minikube

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: medyagh/setup-minikube@master
         id: space-agone
         with:
-          kubernetes-version: v1.24.7
+          kubernetes-version: v1.23.14
           cpus: 2
           memory: 4096m
       - name: Install helm and envsubst

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ make openmatch-install
 ```bash
 # Start minikube
 # ref: https://minikube.sigs.k8s.io/docs/commands/start/
-$ minikube start --cpus="2" --memory="4096" --kubernetes-version=v1.24.7 --driv
+$ minikube start --cpus="2" --memory="4096" --kubernetes-version=v1.23.14 --driv
 er=hyperkit
 
 # Install minimized Agones

--- a/README.md
+++ b/README.md
@@ -228,8 +228,10 @@ $ make integration-test
 
 #### minikube
 
+1. [Create a space-agon k8s cluster via minikube.](#create-the-resources-and-install-gaming-oss)
+
 ```bash
-# Connect to service
+# Connect to service in minikube
 $ minikube tunnel
 
 # Open another terminal and

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -1,4 +1,4 @@
-#  Copyright 2022 Google LLC
+#  Copyright 2017 Google LLC
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What 

- change minikube version in README and CI/CD to adopt the agones support version
- rollback copyright in deploy template
    - ref: https://github.com/googleforgames/space-agon/pull/12#discussion_r1019877263