### PR TITLE
Upgrade Agones to 1.29.0 and Open Match to 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Install tools in your dev environment:
 - [gcloud](https://cloud.google.com/sdk/gcloud)
 - [docker](https://www.docker.com/)
 - [kubectl](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_kubectl)
+- [helm](https://helm.sh/)
 - [envsubst](https://linux.die.net/man/1/envsubst)
 - [skaffold](https://skaffold.dev/) (Optional)
-- [helm](https://helm.sh/) (Optional)
 - [minikube](https://minikube.sigs.k8s.io/docs/start/) (Optional)
 - [hyperkit](https://github.com/moby/hyperkit) (Optional)
 

--- a/scripts/create-cluster.sh
+++ b/scripts/create-cluster.sh
@@ -20,7 +20,7 @@ LOCATION=$3
 NETWORK=$4
 
 gcloud container clusters create space-agon \
-  --cluster-version=1.22 \
+  --cluster-version=1.24 \
   --tags=game-server \
   --scopes=gke-default \
   --network ${NETWORK} \


### PR DESCRIPTION
This PR has a upgrade to Agones and Open Match and change of installing for Open Match

- Upgrade GKE Kubernetes version from 1.22 to 1.24
- Upgrade Agones from 1.27.0 to 1.29.0
- Upgrade Open Match from 1.5.0 to 1.7.0
- Change instaling way for Open Match ※1

※1 One of the Open Match installing way is YAML apply. The default YAML requires more than 4.5 cpu cores, because the StatefulSet's Redis has 3 containers(redis, sentinel, metrics) requre each 0.5 cpus(= total 1.5 cores) and StatefulSet has 3 reqlica(= 1.5cores * 3Pod = total 4.5 cores)