### PR TITLE
Updated Open Match and Kubernetes versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: medyagh/setup-minikube@master
         id: space-agon
         with:
-          kubernetes-version: v1.23.17
+          kubernetes-version: v1.24.16
           cpus: 2
           memory: 4096m
       - name: Install helm

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: medyagh/setup-minikube@master
         id: space-agon
         with:
-          kubernetes-version: v1.24.16
+          kubernetes-version: v1.25.13
           cpus: 2
           memory: 4096m
       - name: Install helm

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ MMF_IMG=space-agon-mmf
 AGONES_NS:=agones-system
 OM_NS:=open-match
 AGONES_VER:=1.29.0
-OM_VER:=1.7.0
+OM_VER:=1.8.0
+K8S_VERSION:=1.25
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___
@@ -132,7 +133,11 @@ gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT ?= 4
 gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= e2-standard-4
 gcloud-test-cluster: NETWORK ?= default
 gcloud-test-cluster:
-	./scripts/create-cluster.sh ${GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT} ${GCP_CLUSTER_NODEPOOL_MACHINETYPE} ${LOCATION} ${NETWORK}
+	./scripts/create-cluster.sh ${GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT} \
+		${GCP_CLUSTER_NODEPOOL_MACHINETYPE} \
+		${LOCATION} \
+		${NETWORK} \
+		${K8S_VERSION}
 
 .PHONY: helm-repo-add
 helm-repo-add: 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ make openmatch-install
 # Start minikube
 # ref: https://minikube.sigs.k8s.io/docs/commands/start/
 # Or you can other dirvers
-minikube start --cpus="2" --memory="4096" --kubernetes-version=v1.23.17 --driver=hyperkit
+minikube start --cpus="2" --memory="4096" --kubernetes-version=v1.24.16 --driver=hyperkit
 
 # Add Helm Repositories 
 make helm-repo-add

--- a/scripts/create-cluster.sh
+++ b/scripts/create-cluster.sh
@@ -18,9 +18,10 @@ GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT=$1
 GCP_CLUSTER_NODEPOOL_MACHINETYPE=$2
 LOCATION=$3
 NETWORK=$4
+K8S_VERSION=$5
 
 gcloud container clusters create space-agon \
-  --cluster-version=1.24 \
+  --cluster-version=${K8S_VERSION} \
   --tags=game-server \
   --scopes=gke-default \
   --network ${NETWORK} \


### PR DESCRIPTION
As [PSP has been removed from Kubernetes 1.25+](https://kubernetes.io/docs/concepts/security/pod-security-policy/), Open Match needs to purge dependent helm charts from the repository.

Since Open Match released [1.8.0](https://github.com/googleforgames/open-match/releases/tag/v1.8.0), I've tested on Space Agon and updated its kubernetes version to 1.25. 

This PR closes #34.

