### PR TITLE
Add initial unit tests for dedicated and protostream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ upgrade:
 # unit test
 .PHONY: test
 test:
-	go test ./frontend/ ./mmf/ ./director/ ./dedicated/
+	go test ./frontend/ ./mmf/ ./director/ ./dedicated/ ./game/protostream/
 
 # integration test
 .PHONY: integration-test

--- a/dedicated/dedicated_test.go
+++ b/dedicated/dedicated_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/googleforgames/space-agon/game/pb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMemoRecipient(t *testing.T) {
+
+	tests := []struct {
+		cid              int64
+		memo             *pb.Memo
+		name             string
+		isPanic          bool
+		correctRecipient bool
+	}{
+		{
+			cid: int64(1),
+			memo: &pb.Memo{
+				Recipient: &pb.Memo_To{
+					To: int64(1),
+				},
+			},
+			name:             "correct Memo_to recipient",
+			isPanic:          false,
+			correctRecipient: true,
+		},
+		{
+			cid: int64(1),
+			memo: &pb.Memo{
+				Recipient: &pb.Memo_To{
+					To: int64(2),
+				},
+			},
+			name:             "incorrect Memo_to recipient",
+			isPanic:          false,
+			correctRecipient: false,
+		},
+		{
+			cid: int64(2),
+			memo: &pb.Memo{
+				Recipient: &pb.Memo_EveryoneBut{
+					EveryoneBut: int64(1),
+				},
+			},
+			name:             "correct Memo_EveryoneBut recipient",
+			isPanic:          false,
+			correctRecipient: true,
+		},
+		{
+			cid: int64(1),
+			memo: &pb.Memo{
+				Recipient: &pb.Memo_EveryoneBut{
+					EveryoneBut: int64(1),
+				},
+			},
+			name:             "incorrect Memo_EveryoneBut recipient",
+			isPanic:          false,
+			correctRecipient: false,
+		},
+		{
+			cid:              int64(12),
+			memo:             &pb.Memo{},
+			name:             "unknown memo recipient",
+			isPanic:          true,
+			correctRecipient: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.isPanic {
+				assert.Panics(t, func() {
+					isMemoRecipient(test.cid, test.memo)
+				})
+			} else if test.correctRecipient {
+				assert.True(t, isMemoRecipient(test.cid, test.memo))
+			} else {
+				assert.False(t, isMemoRecipient(test.cid, test.memo))
+			}
+		})
+	}
+}

--- a/game/protostream/protostream_test.go
+++ b/game/protostream/protostream_test.go
@@ -1,0 +1,26 @@
+package protostream
+
+import (
+	"testing"
+)
+
+func TestDecodeVarint(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected uint64
+		length   int
+		name     string
+	}{
+		{[]byte{0x00}, 0, 1, "zero value"},
+		{[]byte{0x01}, 1, 1, "positive value"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, length := DecodeVarint(test.input)
+			if result != test.expected || length != test.length {
+				t.Errorf("got result: %v, length: %v, expected result: %v, length: %v)", result, length, test.expected, test.length)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Regarding this issue: https://github.com/googleforgames/space-agon/issues/1, 

Im adding initial pr, to improve test coverage, 

if this seems good, I can add more test coverage in another pr

gentle ping for @govargo 