### PR TITLE
Fix goroutine leak in game frontend

### DIFF
--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -119,14 +119,19 @@ func streamAssignments(ctx context.Context, assignments chan *pb.Assignment, err
 		errs <- fmt.Errorf("error getting assignment stream: %w", err)
 		return
 	}
-	for {
+
+	var assignment *pb.Assignment
+	for assignment.GetConnection() == "" {
 		resp, err := stream.Recv()
 		if err != nil {
 			errs <- fmt.Errorf("error streaming assignment: %w", err)
 			return
 		}
-		assignments <- resp.Assignment
+		assignment = resp.Assignment
 	}
+
+	assignments <- assignment
+	log.Printf("Got assignment: %v", assignment)
 }
 
 func connectFrontendServer() (*grpc.ClientConn, error) {

--- a/game/pb/messages.pb.go
+++ b/game/pb/messages.pb.go
@@ -21,10 +21,11 @@
 package pb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (


### PR DESCRIPTION
When I wrote the code with following `space-agon`'s codebase, I found that my code has leaked goroutine in the container process.

<img width="506" alt="スクリーンショット 2024-06-28 20 37 58" src="https://github.com/googleforgames/space-agon/assets/44902466/8fc09326-0d06-48ab-8eb4-ae7d234fdc79">

I investigated and found that the following code in game frontend doesn't release the goroutine by e.g. `break`, `return`.

```
# current code
for {
  resp, err := stream.Recv()
  if err != nil {
    errs <- fmt.Errorf("error streaming assignment: %w", err)
    return
  }
  assignments <- resp.Assignment
}
```

This code leads to goroutine leak.
This PR fixes this problem.

I followed the example in open-match client example's code.
https://github.com/googleforgames/open-match/blob/main/examples/demo/components/clients/clients.go#L119-L126