### PR TITLE
use public om2 image

### DIFF
--- a/om_install.yaml
+++ b/om_install.yaml
@@ -28,7 +28,7 @@ spec:
         app: open-match-deployment
     spec:
       containers:
-        - image: OM_CORE_IMAGE
+        - image: us-docker.pkg.dev/open-match-public-images/open-match2/om-core
           name: core 
           ports:
           - containerPort: 8080


### PR DESCRIPTION
Use the public image URL for OM2 on https://pantheon.corp.google.com/artifacts/docker/open-match-public-images/us/open-match2/om-core?e=13803378&mods=allow_workbench_image_override&project=open-match-public-images